### PR TITLE
pairwise_pmi_ using properties of logs for improved numerical precission

### DIFF
--- a/R/pairwise_pmi.R
+++ b/R/pairwise_pmi.R
@@ -46,12 +46,12 @@ pairwise_pmi <- function(tbl, item, feature, sort = FALSE) {
 #' @export
 pairwise_pmi_ <- function(tbl, item, feature, sort = FALSE) {
   f <- function(m) {
-    row_sums <- rowSums(m) / sum(m)
+    row_sums <- log(rowSums(m) / sum(m))
 
     ret <- m %*% t(m)
-    ret <- ret / sum(ret)
-    ret <- ret / row_sums
-    ret <- t(t(ret) / (row_sums))
+    ret <- log(ret) - log(sum(ret))
+    ret <- ret - row_sums
+    ret <- t(t(ret) - (row_sums))
     ret
   }
   pmi_func <- squarely_(f, sparse = TRUE, sort = sort)
@@ -60,6 +60,5 @@ pairwise_pmi_ <- function(tbl, item, feature, sort = FALSE) {
     ungroup() %>%
     mutate(..value = 1) %>%
     pmi_func(item, feature, "..value") %>%
-    mutate(value = log(value)) %>%
     rename(pmi = value)
 }


### PR DESCRIPTION
This PR makes minor changes in `pairwise_pmi_` to improve numerical precision. Unfortunately, for some reason `pairwise_pmi` **gets broken** with error:

```
Error in `colnames<-`(`*tmp*`, value = c("item1", "item2", "value")) : 
  attempt to set 'colnames' on an object with less than two dimensions
```

At this point the error message is pretty cryptic for me since `log()` function does not drop neither dimensions, nor attributes (names, colnames etc.) of objects, so it should have no impact whatsoever.

I'm posting the PR regardless of the error since it may possibly point at some problems with the package itself (sorry, I wasn't able to track it yet).